### PR TITLE
Disable autoFocus property after manual focus.

### DIFF
--- a/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -989,6 +989,10 @@ public class Camera {
 /*
         Log.d(previewSize, "Manual focus already engaged");
         Log.d(sensorArraySize.height(), "Manual focus already engaged");*/
+
+        // Disable auto focus
+        mAutoFocus = false;
+
         final Rect sensorArraySize = mCameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
 
         final int x = (int)(offsetX  * (float)sensorArraySize.height());


### PR DESCRIPTION
There was a problem on Android - when user opens the camera and takes a picture, everything works fine. However, when he opens the camera, manually sets focus and then takes a picture, camera hanged and it was impossible to take a picture.